### PR TITLE
bug fix: beam_threshold is in log_10 and needs to be transformed befo…

### DIFF
--- a/src/fast_align.cc
+++ b/src/fast_align.cc
@@ -421,7 +421,7 @@ int main(int argc, char** argv) {
   }
   if (!force_align && !conditional_probability_filename.empty()) {
     cerr << "conditional probabilities: " << conditional_probability_filename << endl;
-    s2t.ExportToFile(conditional_probability_filename.c_str(), d, beam_threshold);
+    s2t.ExportToFile(conditional_probability_filename.c_str(), d, pow(10.0, beam_threshold));
   }
   if (force_align) {
     istream* pin = &cin;

--- a/src/ttables.h
+++ b/src/ttables.h
@@ -149,9 +149,10 @@ class TTable {
       const double threshold = max_p * BEAM_THRESHOLD;
       for (auto& it : cpd) {
         const std::string& b = d.Convert(it.first);
-        double c = log(it.second);
-        if (c >= threshold)
+        if (it.second >= threshold) {
+          double c = log(it.second);
           file << a << '\t' << b << '\t' << c << std::endl;
+        }
       }
     }
     file.close();


### PR DESCRIPTION
…re it's passed the the ttable.


beam_threshold is the a threshold in log space (indicated by it's default value of -4.0). It used to be directly passed like this to ExportToFile, which then internally got multiplied with max_p (a probability NOT in log space) to get the threshold. This threshold was then used to be compare to log probabilities. This led to everything being pruned if max_p < 0.3 (e.g. if max_p=0.2 then threshold=0.2*-4=-0.8 which leads to log(max_p) < threshold). Anyway, I changed this to directly pass a probability to ExportToFile, so that probabilities are compare to probabilities.