### PR TITLE
Fix arithmetic bug in DiagonalAlignment compuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ fast_align
 `fast_align` is a simple, fast, unsupervised word aligner.
 
 If you use this software, please cite:
-* [Chris Dyer](http://www.cs.cmu.edu/~cdyer), [Victor Chahuneau](http://victor.chahuneau.fr), and [Noah A. Smith](http://www.cs.cmu.edu/~nasmith). (2013). [A Simple, Fast, and Effective Reparameterization of IBM Model 2](http://www.ark.cs.cmu.edu/cdyer/fast_valign.pdf). In *Proc. of NAACL*.
+* [Chris Dyer](http://www.cs.cmu.edu/~cdyer), [Victor Chahuneau](http://victor.chahuneau.fr), and [Noah A. Smith](http://www.cs.cmu.edu/~nasmith). (2013). [A Simple, Fast, and Effective Reparameterization of IBM Model 2](http://www.aclweb.org/anthology/N13-1073). In *Proc. of NAACL*.
 
 The source code in this repository is provided under the terms of the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html).
 

--- a/src/da.h
+++ b/src/da.h
@@ -86,7 +86,7 @@ struct DiagonalAlignment {
     const double x_1 = a_1 * g_1;
     const double g_2 = g_1 * r;
     const double rm1 = r - 1;
-    return (a_n * g_np1 - x_1) / rm1 - d*(g_np1 - g_2) / (rm1 * rm1);
+    return (a_n * g_np1 - x_1) / rm1 + d*(g_np1 - g_2) / (rm1 * rm1);
   }
 };
 


### PR DESCRIPTION
The computation in DiagonalAlignment seems to be incorrect given the first equation under section 3.4 in the original paper. In the implementation, the second term is subtracted, whereas in the paper, the second term is added.
![da-equation](https://cloud.githubusercontent.com/assets/8755768/18356849/8c97a864-75bc-11e6-9258-c1ea2b2d124a.png)

As an aside, the link to the original paper is broken. I've updated it to the ACL anthology link.