### PR TITLE
Changed Beam Threshold 

### DIFF
--- a/src/ttables.h
+++ b/src/ttables.h
@@ -146,7 +146,7 @@ class TTable {
       double max_p = -1;
       for (auto& it : cpd)
         if (it.second > max_p) max_p = it.second;
-      const double threshold = log(max_p) + BEAM_THRESHOLD;
+      const double threshold = log(max_p) + (BEAM_THRESHOLD * log(10));
       for (auto& it : cpd) {
         const std::string& b = d.Convert(it.first);
         double c = log(it.second);

--- a/src/ttables.h
+++ b/src/ttables.h
@@ -146,7 +146,7 @@ class TTable {
       double max_p = -1;
       for (auto& it : cpd)
         if (it.second > max_p) max_p = it.second;
-      const double threshold = - log(max_p) * BEAM_THRESHOLD;
+      const double threshold = log(max_p) + BEAM_THRESHOLD;
       for (auto& it : cpd) {
         const std::string& b = d.Convert(it.first);
         double c = log(it.second);


### PR DESCRIPTION
- The older expression (before May) was comparing probabilities with logarithms, and although this was fixed with the previous commit the expression should be a sum and not a multiplication, to keep the same meaning. 
- Also, multiplying the beam threshold with the log(10) factor turns the parameter more intuitive
- The default threshold also makes more sense with this expression