### PR TITLE
Fixing the non-deterministic behaviour of multi-thread FA.

### DIFF
--- a/src/ttables.h
+++ b/src/ttables.h
@@ -78,7 +78,9 @@ class TTable {
   }
 
   inline void Increment(const unsigned e, const unsigned f, const double x) {
-    counts[e].find(f)->second += x; // Ignore race conditions here.
+// Each thread locks only the part of the table which is writing on. Other threads have access to the rest of the table to update!
+#pragma omp atomic
+    counts[e].find(f)->second += x;.
   }
 
   void NormalizeVB(const double alpha) {


### PR DESCRIPTION
I noticed that in Linux the code is not thread-safe, and produces different models and alignments in different runs. In Mac, however, it behaves deterministically. I assume this is due to different thread handling mechanisms of Linux and Mac.
The issue is due to the Increment function in ttables.h where there is a race between the threads in updating the table. The safest and most efficient way to handle this situation is to use "atomic" declaration which just locks the current cell for the given thread and leaves the rest of the table free for the other threads to write on.
By this fix we can solve the issue and obtain identical models in different runs. However, I noticed that in very few cases the final alignment might slightly vary. This is another issue which doesn't have anything to do the with the thread safety of the code. I believe it happens only in the very special cases where the probability of aligning a source word to target words is very low (almost zero). In those cases the code might select one of the candidate by chance. In my test set this situation happens only in 0.005% of the cases.