### PR TITLE
Resolves [BUG] tot_len_ratio being inf when src.size() is zero

### DIFF
--- a/src/fast_align.cc
+++ b/src/fast_align.cc
@@ -247,6 +247,7 @@ void InitialPass(const unsigned kNULL, const bool use_null, TTable* s2t,
   string line;
   bool flag = false;
   int lc = 0;
+  int skipped_lines = 0;
   cerr << "INITIAL PASS " << endl;
   while (true) {
     getline(in, line);
@@ -259,7 +260,9 @@ void InitialPass(const unsigned kNULL, const bool use_null, TTable* s2t,
     if (is_reverse)
       swap(src, trg);
     if (src.size() == 0 || trg.size() == 0) {
-      cerr << "Error in line " << lc << "\n" << line << endl;
+      cerr << "Error in line " << lc << ". Skipped.\n" << line << endl;
+      skipped_lines++;
+      continue;
     }
     *tot_len_ratio += static_cast<double>(trg.size()) / static_cast<double>(src.size());
     *n_target_tokens += trg.size();
@@ -288,10 +291,11 @@ void InitialPass(const unsigned kNULL, const bool use_null, TTable* s2t,
   }
   AddTranslationOptions(insert_buffer, s2t);
 
-  mean_srclen_multiplier = (*tot_len_ratio) / lc;
+  mean_srclen_multiplier = (*tot_len_ratio) / (lc - skipped_lines);
   if (flag) {
     cerr << endl;
   }
+  cerr << "number of skipped lines = " << skipped_lines << endl;
   cerr << "expected target length = source length * " << mean_srclen_multiplier << endl;
 }
 


### PR DESCRIPTION
Resolves ["[BUG] tot_len_ratio being inf when src.size() is zero"](https://github.com/clab/fast_align/issues/39) by skipping lines with zero length.