### PR TITLE
Fix comparison of differently signed types

### DIFF
--- a/src/ttables.cc
+++ b/src/ttables.cc
@@ -17,7 +17,7 @@ void TTable::DeserializeLogProbsFromText(istream* in, Dict& d) {
     if (e.empty()) break;
     ++c;
     unsigned ie = d.Convert(e);
-    if (ie >= static_cast<int>(ttable.size())) ttable.resize(ie + 1);
+    if (ie >= static_cast<unsigned int>(ttable.size())) ttable.resize(ie + 1);
     ttable[ie][d.Convert(f)] = exp(p);
   }
   cerr << "Loaded " << c << " translation parameters.\n";


### PR DESCRIPTION
I may be missing something, but what is the reason for this not being casted to `unsigned int`?