### PR TITLE
Add command option to print align scores

### DIFF
--- a/src/force_align.py
+++ b/src/force_align.py
@@ -82,6 +82,10 @@ def main():
         sys.stderr.write('  {} fwd_params fwd_err rev_params rev_err [heuristic] <in.f-e >out.f-e.gdfa\n'.format(sys.argv[0]))
         sys.stderr.write('\n')
         sys.stderr.write('where heuristic is one of: (intersect union grow-diag grow-diag-final grow-diag-final-and) default=grow-diag-final-and\n')
+        sys.stderr.write('To see alignment scores, run:\n')
+        sys.stderr.write('  {} fwd_params fwd_err rev_params rev_err heuristic fwdbwd <in.f-e >out.f-e.gdfa\n'.format(sys.argv[0]))
+        sys.stderr.write('\n')
+        sys.stderr.write('This will show fwd and bwd align score seperated with tab following the alignment pairs.\n')
         sys.exit(2)
 
     aligner = Aligner(*sys.argv[1:])


### PR DESCRIPTION
This PR is slight augmentation of adding command option to append forward and backward align scores on the alignment pairs.
(It's similar with #44 but more non-intrusive way :) , just modifying one python file. )

For examples,

- Basic usage
```console
$ python force_align.py fwd_params fwd_err rev_params rev_err
0-0 1-1 2-1 2-2 3-3 4-2 5-4 6-5 6-7 7-6 8-5
0-0 1-1 2-2 3-2 3-3 4-4 5-5 5-6 6-7 6-9 7-8 8-9 9-10
0-0 0-1 1-3 2-4 3-5
```

- Added command option append forward and backward score separated with tabs.
```console
$ python force_align.py fwd_params fwd_err rev_params rev_err grow-diag-final-and fwdbwd
0-0 1-1 2-1 2-2 3-3 4-2 5-4 6-5 6-7 7-6 8-5     -45.1583        -75.626
0-0 1-1 2-2 3-2 3-3 4-4 5-5 5-6 6-7 6-9 7-8 8-9 9-10    -68.421 -71.7015
0-0 0-1 1-3 2-4 3-5     -37.883 -14.6208
```